### PR TITLE
Issue 2 safety tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare"
+    "postinstall": "nuxt prepare",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "packageManager": "pnpm@10.5.2",
   "pnpm": {
@@ -48,7 +51,9 @@
   },
   "devDependencies": {
     "@nuxtjs/tailwindcss": "6.13.1",
+    "@vitest/coverage-v8": "^4.0.18",
     "pino-pretty": "^13.0.0",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "vitest": "^4.0.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,12 +90,18 @@ importers:
       '@nuxtjs/tailwindcss':
         specifier: 6.13.1
         version: 6.13.1(magicast@0.3.5)
+      '@vitest/coverage-v8':
+        specifier: ^4.0.18
+        version: 4.0.18(vitest@4.0.18(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
       pino-pretty:
         specifier: ^13.0.0
         version: 13.0.0
       typescript:
         specifier: 5.8.2
         version: 5.8.2
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
 
 packages:
 
@@ -176,8 +182,16 @@ packages:
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.25.9':
@@ -190,6 +204,11 @@ packages:
 
   '@babel/parser@7.26.9':
     resolution: {integrity: sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -249,6 +268,14 @@ packages:
   '@babel/types@7.26.9':
     resolution: {integrity: sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@cloudflare/kv-asset-handler@0.3.4':
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
@@ -646,8 +673,14 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@koa/router@12.0.2':
     resolution: {integrity: sha512-sYcHglGKTxGF+hQ6x67xDfkE9o+NhVlRHBqq6gLywaMc6CojK/5vFZByphdonKinYlMLkEkacm+HEse9HzwgTA==}
@@ -1210,6 +1243,9 @@ packages:
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1237,6 +1273,12 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1291,6 +1333,44 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
+
+  '@vitest/coverage-v8@4.0.18':
+    resolution: {integrity: sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==}
+    peerDependencies:
+      '@vitest/browser': 4.0.18
+      vitest: 4.0.18
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   '@vue-macros/common@1.16.1':
     resolution: {integrity: sha512-Pn/AWMTjoMYuquepLZP813BIcq8DTZiNCoaceuNlvaYuOTd8DqBZWc5u0uOMQZMInwME1mdSmmBAcTluiV9Jtg==}
@@ -1458,9 +1538,16 @@ packages:
     resolution: {integrity: sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==}
     engines: {node: '>=10'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@1.4.0:
     resolution: {integrity: sha512-BlGeOw73FDsX7z0eZE/wuuafxYoek2yzNJ6l6A1nsb4+z/p87TOPbHaWuN53kFKNuUXiCQa2M+xLF71IqQmRSw==}
     engines: {node: '>=16.14.0'}
+
+  ast-v8-to-istanbul@0.3.11:
+    resolution: {integrity: sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==}
 
   ast-walker-scope@0.6.2:
     resolution: {integrity: sha512-1UWOyC50xI3QZkRuDj6PqDtpm1oHWtYs+NQGwqL/2R11eN3Q81PHAHPM0SWW3BNQm53UDwS//Jv8L4CCVLM1bQ==}
@@ -1596,6 +1683,10 @@ packages:
 
   caniuse-lite@1.0.30001702:
     resolution: {integrity: sha512-LoPe/D7zioC0REI5W73PeR1e1MLCipRGq/VkovJnd6Df+QVqT+vT33OXCp8QUd7kA7RZrHWxb1B36OQKI/0gOA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2012,6 +2103,9 @@ packages:
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2066,6 +2160,10 @@ packages:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
 
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
   exsolve@1.0.1:
     resolution: {integrity: sha512-Smf0iQtkQVJLaph8r/qS8C8SWfQkaq9Q/dFcD44MLbJj6DNhlWefVuaS21SjfqOsBbjVlKtbCj6L9ekXK6EZUg==}
 
@@ -2115,6 +2213,15 @@ packages:
 
   fdir@6.4.3:
     resolution: {integrity: sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
     peerDependencies:
       picomatch: ^3 || ^4
     peerDependenciesMeta:
@@ -2285,6 +2392,9 @@ packages:
 
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
@@ -2464,6 +2574,18 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
@@ -2488,6 +2610,9 @@ packages:
   js-levenshtein@1.1.6:
     resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
     engines: {node: '>=0.10.0'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2629,8 +2754,18 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2881,6 +3016,9 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
 
@@ -3008,6 +3146,10 @@ packages:
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -3485,6 +3627,9 @@ packages:
     resolution: {integrity: sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3535,6 +3680,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -3545,6 +3693,9 @@ packages:
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   std-env@3.8.1:
     resolution: {integrity: sha512-vj5lIj3Mwf9D79hBkltk5qmkFI+biIKWS2IBxEyEU3AX1tUf7AoL8nSazCOiiqQsGKIq01SClsKEzweu34uwvA==}
@@ -3683,8 +3834,15 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.10:
     resolution: {integrity: sha512-Zc+8eJlFMvgatPZTl6A9L/yht8QqdmUNtURHaKZLmKBE12hNPSrqNkUp2cs3M/UKmNVVAMFQYSjYIVHDjW5zew==}
@@ -3694,8 +3852,16 @@ packages:
     resolution: {integrity: sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
@@ -4000,6 +4166,40 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-jsonrpc@6.0.0:
     resolution: {integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==}
     engines: {node: '>=8.0.0 || >=10.0.0'}
@@ -4071,6 +4271,11 @@ packages:
   which@3.0.1:
     resolution: {integrity: sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrap-ansi@7.0.0:
@@ -4259,7 +4464,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.25.9': {}
 
@@ -4271,6 +4480,10 @@ snapshots:
   '@babel/parser@7.26.9':
     dependencies:
       '@babel/types': 7.26.9
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@babel/plugin-proposal-decorators@7.25.9(@babel/core@7.26.9)':
     dependencies:
@@ -4341,6 +4554,13 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@cloudflare/kv-asset-handler@0.3.4':
     dependencies:
@@ -4608,7 +4828,14 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -4882,7 +5109,7 @@ snapshots:
       semver: 7.7.1
       simple-git: 3.27.0
       sirv: 3.0.1
-      tinyglobby: 0.2.10
+      tinyglobby: 0.2.12
       unimport: 3.14.6(rollup@4.34.9)
       vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
       vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.9)(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
@@ -5272,6 +5499,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -5296,6 +5525,13 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.6': {}
 
@@ -5374,6 +5610,59 @@ snapshots:
     dependencies:
       vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.8.2)
+
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.0.18
+      ast-v8-to-istanbul: 0.3.11
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 3.10.0
+      tinyrainbow: 3.0.3
+      vitest: 4.0.18(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   '@vue-macros/common@1.16.1(vue@3.5.13(typescript@5.8.2))':
     dependencies:
@@ -5598,10 +5887,18 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   ast-kit@1.4.0:
     dependencies:
       '@babel/parser': 7.26.9
       pathe: 2.0.3
+
+  ast-v8-to-istanbul@0.3.11:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   ast-walker-scope@0.6.2:
     dependencies:
@@ -5765,6 +6062,8 @@ snapshots:
       lodash.uniq: 4.5.0
 
   caniuse-lite@1.0.30001702: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6109,6 +6408,8 @@ snapshots:
 
   es-module-lexer@1.6.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -6213,6 +6514,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expect-type@1.3.0: {}
+
   exsolve@1.0.1: {}
 
   externality@1.0.2:
@@ -6284,6 +6587,10 @@ snapshots:
   fdir@6.4.3(picomatch@4.0.2):
     optionalDependencies:
       picomatch: 4.0.2
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
 
   file-uri-to-path@1.0.0: {}
 
@@ -6471,6 +6778,8 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-escaper@2.0.2: {}
+
   html-tags@3.3.1: {}
 
   http-assert@1.5.0:
@@ -6644,6 +6953,19 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jackspeak@3.4.3:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -6661,6 +6983,8 @@ snapshots:
   joycon@3.1.1: {}
 
   js-levenshtein@1.1.6: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -6835,11 +7159,25 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.26.9
       '@babel/types': 7.26.9
       source-map-js: 1.2.1
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.1
 
   math-intrinsics@1.1.0: {}
 
@@ -7239,6 +7577,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  obug@2.1.1: {}
+
   ofetch@1.4.1:
     dependencies:
       destr: 2.0.3
@@ -7365,6 +7705,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.2: {}
+
+  picomatch@4.0.3: {}
 
   pify@2.3.0: {}
 
@@ -7881,6 +8223,8 @@ snapshots:
 
   shell-quote@1.8.2: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7924,11 +8268,15 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
   statuses@1.5.0: {}
 
   statuses@2.0.1: {}
+
+  std-env@3.10.0: {}
 
   std-env@3.8.1: {}
 
@@ -8119,7 +8467,11 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.10:
     dependencies:
@@ -8131,7 +8483,14 @@ snapshots:
       fdir: 6.4.3(picomatch@4.0.2)
       picomatch: 4.0.2
 
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
   tinyrainbow@1.2.0: {}
+
+  tinyrainbow@3.0.3: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8424,6 +8783,43 @@ snapshots:
       terser: 5.39.0
       yaml: 2.7.0
 
+  vitest@4.0.18(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@6.2.0(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 6.2.0(@types/node@22.13.9)(jiti@2.4.2)(terser@5.39.0)(yaml@2.7.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.13.9
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
   vscode-jsonrpc@6.0.0: {}
 
   vscode-languageclient@7.0.0:
@@ -8488,6 +8884,11 @@ snapshots:
   which@3.0.1:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@7.0.0:
     dependencies:

--- a/tests/api/common/clients.test.ts
+++ b/tests/api/common/clients.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('~/lib/prisma', () => ({
+  default: {
+    providers: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('openid-client', async () => {
+  class MockClient {
+    constructor(public config: any) {}
+    authorizationUrl = vi.fn()
+    callback = vi.fn()
+  }
+  const mockIssuer = {
+    Client: MockClient,
+  }
+  return {
+    Issuer: {
+      discover: vi.fn().mockResolvedValue(mockIssuer),
+    },
+    generators: {
+      codeVerifier: vi.fn().mockReturnValue('mock-verifier'),
+      codeChallenge: vi.fn().mockReturnValue('mock-challenge'),
+    },
+    BaseClient: vi.fn(),
+    discovery: vi.fn().mockResolvedValue({ serverMetadata: () => ({}) }),
+    randomPKCECodeVerifier: vi.fn().mockReturnValue('mock-pkce-verifier'),
+    calculatePKCECodeChallenge: vi.fn().mockResolvedValue('mock-pkce-challenge'),
+    randomState: vi.fn().mockReturnValue('mock-state'),
+    buildAuthorizationUrl: vi.fn().mockReturnValue(new URL('https://example.com/auth')),
+    authorizationCodeGrant: vi.fn().mockResolvedValue({
+      access_token: 'mock-access-token',
+      id_token: 'mock-id-token',
+    }),
+  }
+})
+
+describe('api/common/clients', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('clients と misskeyClients がエクスポートされている', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findMany).mockResolvedValue([])
+
+    const mod = await import('~/api/common/clients')
+    expect(mod.clients).toBeDefined()
+    expect(mod.misskeyClients).toBeDefined()
+    expect(typeof mod.clients).toBe('object')
+    expect(typeof mod.misskeyClients).toBe('object')
+  })
+
+  it('OIDCプロバイダーのクライアントが正しく初期化される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findMany).mockResolvedValue([
+      {
+        id: 'provider-1',
+        name: 'Google',
+        url: 'https://accounts.google.com',
+        clientId: 'google-client-id',
+        clientSecret: 'google-client-secret',
+        scope: 'openid profile email',
+        isMisskey: false,
+      } as any,
+    ])
+
+    const mod = await import('~/api/common/clients')
+    // initOIDCClients は import 時に自動的に呼ばれる
+    // 非同期のため即時反映されない可能性がある
+    await new Promise((r) => setTimeout(r, 100))
+
+    const { Issuer } = await import('openid-client')
+    expect(Issuer.discover).toHaveBeenCalledWith('https://accounts.google.com')
+  })
+
+  it('Misskeyプロバイダーのクライアントが正しく初期化される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findMany).mockResolvedValue([
+      {
+        id: 'provider-2',
+        name: 'Misskey',
+        url: 'https://misskey.io',
+        clientId: 'misskey-client-id',
+        clientSecret: null,
+        scope: 'read:account',
+        isMisskey: true,
+      } as any,
+    ])
+
+    const mod = await import('~/api/common/clients')
+    await new Promise((r) => setTimeout(r, 100))
+
+    const oidcV6 = await import('openid-client')
+    expect(oidcV6.discovery).toHaveBeenCalledWith(
+      new URL('https://misskey.io'),
+      'misskey-client-id'
+    )
+  })
+})

--- a/tests/api/common/const.test.ts
+++ b/tests/api/common/const.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+describe('api/common/const', () => {
+  const originalEnv = process.env
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('開発環境ではisProdがfalseになる', async () => {
+    process.env.NODE_ENV = 'development'
+    const mod = await import('~/api/common/const')
+    expect(mod.isProd).toBe(false)
+  })
+
+  it('本番環境ではisProdがtrueになる', async () => {
+    process.env.NODE_ENV = 'production'
+    const mod = await import('~/api/common/const')
+    expect(mod.isProd).toBe(true)
+  })
+
+  it('開発環境ではhttpプロトコルが使われる', async () => {
+    process.env.NODE_ENV = 'development'
+    delete process.env.OVERRIDE_PROTOCOL
+    delete process.env.HOST
+    const mod = await import('~/api/common/const')
+    expect(mod.protocol).toBe('http')
+    expect(mod.host).toBe('http://localhost:3000')
+  })
+
+  it('HOST環境変数でホストを上書きできる', async () => {
+    process.env.NODE_ENV = 'development'
+    process.env.HOST = 'example.com'
+    delete process.env.OVERRIDE_PROTOCOL
+    const mod = await import('~/api/common/const')
+    expect(mod.host).toBe('http://example.com')
+  })
+
+  it('OVERRIDE_PROTOCOLでプロトコルを上書きできる', async () => {
+    process.env.NODE_ENV = 'development'
+    process.env.OVERRIDE_PROTOCOL = 'https'
+    process.env.HOST = 'example.com'
+    const mod = await import('~/api/common/const')
+    expect(mod.protocol).toBe('https')
+    expect(mod.host).toBe('https://example.com')
+  })
+})

--- a/tests/api/common/misskeyAuthStorage.test.ts
+++ b/tests/api/common/misskeyAuthStorage.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { misskeyAuthStorage } from '~/api/common/helper/misskeyAuthStorage'
+
+describe('misskeyAuthStorage', () => {
+  it('値の保存と取得ができる', async () => {
+    await misskeyAuthStorage.setItem('test-key', 'test-value')
+    const value = await misskeyAuthStorage.getItem<string>('test-key')
+    expect(value).toBe('test-value')
+  })
+
+  it('存在しないキーはnullを返す', async () => {
+    const value = await misskeyAuthStorage.getItem<string>('nonexistent-key')
+    expect(value).toBeNull()
+  })
+
+  it('値の上書きができる', async () => {
+    await misskeyAuthStorage.setItem('overwrite-key', 'first')
+    await misskeyAuthStorage.setItem('overwrite-key', 'second')
+    const value = await misskeyAuthStorage.getItem<string>('overwrite-key')
+    expect(value).toBe('second')
+  })
+
+  it('値の削除ができる', async () => {
+    await misskeyAuthStorage.setItem('remove-key', 'value')
+    await misskeyAuthStorage.removeItem('remove-key')
+    const value = await misskeyAuthStorage.getItem<string>('remove-key')
+    expect(value).toBeNull()
+  })
+})

--- a/tests/api/v0/auth.test.ts
+++ b/tests/api/v0/auth.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockAuthorizationUrl = vi.fn().mockReturnValue('https://provider.example.com/auth?code_challenge=xxx')
+const mockCodeVerifier = vi.fn().mockReturnValue('test-code-verifier')
+const mockCodeChallenge = vi.fn().mockReturnValue('test-code-challenge')
+
+vi.mock('~/lib/prisma', () => ({
+  default: {
+    providers: {
+      findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  },
+}))
+
+vi.mock('openid-client', () => ({
+  Issuer: {
+    discover: vi.fn(),
+  },
+  generators: {
+    codeVerifier: mockCodeVerifier,
+    codeChallenge: mockCodeChallenge,
+  },
+  BaseClient: vi.fn(),
+  discovery: vi.fn(),
+  randomPKCECodeVerifier: vi.fn(),
+  calculatePKCECodeChallenge: vi.fn(),
+  randomState: vi.fn(),
+  buildAuthorizationUrl: vi.fn(),
+  authorizationCodeGrant: vi.fn(),
+}))
+
+vi.mock('~/api/common/clients', () => ({
+  clients: {
+    google: {
+      authorizationUrl: mockAuthorizationUrl,
+    },
+  },
+  misskeyClients: {},
+}))
+
+describe('api/v0/auth - OIDC認証フロー', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('authモジュールがエクスポートされる', async () => {
+    const { auth } = await import('~/api/v0/auth')
+    expect(auth).toBeDefined()
+  })
+
+  it('有効なプロバイダーでリダイレクトされる', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'p1',
+      name: 'Google',
+      url: 'https://accounts.google.com',
+      clientId: 'google-id',
+      clientSecret: 'google-secret',
+      scope: 'openid profile email',
+      isMisskey: false,
+    } as any)
+
+    const { auth } = await import('~/api/v0/auth')
+    const res = await auth.request(
+      new Request('http://localhost/google'),
+      undefined,
+      {}
+    )
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe(
+      'https://provider.example.com/auth?code_challenge=xxx'
+    )
+  })
+
+  it('無効なプロバイダーで400エラーが返る', async () => {
+    const { auth } = await import('~/api/v0/auth')
+    const res = await auth.request(
+      new Request('http://localhost/invalid'),
+      undefined,
+      {}
+    )
+
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toBe('Invalid provider')
+  })
+
+  it('PKCE code_verifierがCookieに設定される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'p1',
+      name: 'Google',
+      url: 'https://accounts.google.com',
+      clientId: 'google-id',
+      clientSecret: 'google-secret',
+      scope: 'openid profile email',
+      isMisskey: false,
+    } as any)
+
+    const { auth } = await import('~/api/v0/auth')
+    const res = await auth.request(
+      new Request('http://localhost/google'),
+      undefined,
+      {}
+    )
+
+    const cookies = res.headers.get('set-cookie') || ''
+    expect(cookies).toContain('code_verifier=')
+    expect(cookies).toContain('HttpOnly')
+  })
+
+  it('authorizationUrlにS256のcode_challenge_methodが渡される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'p1',
+      name: 'Google',
+      url: 'https://accounts.google.com',
+      clientId: 'google-id',
+      clientSecret: 'google-secret',
+      scope: 'openid profile email',
+      isMisskey: false,
+    } as any)
+
+    const { auth } = await import('~/api/v0/auth')
+    await auth.request(
+      new Request('http://localhost/google'),
+      undefined,
+      {}
+    )
+
+    expect(mockAuthorizationUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code_challenge_method: 'S256',
+        code_challenge: 'test-code-challenge',
+        scope: 'openid profile email',
+      })
+    )
+  })
+
+  it('generators.codeVerifierとcodeChallengeが正しく使われる', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'p1',
+      name: 'Google',
+      url: 'https://accounts.google.com',
+      clientId: 'google-id',
+      clientSecret: 'google-secret',
+      scope: 'openid profile email',
+      isMisskey: false,
+    } as any)
+
+    const { auth } = await import('~/api/v0/auth')
+    await auth.request(
+      new Request('http://localhost/google'),
+      undefined,
+      {}
+    )
+
+    expect(mockCodeVerifier).toHaveBeenCalledOnce()
+    expect(mockCodeChallenge).toHaveBeenCalledWith('test-code-verifier')
+  })
+})

--- a/tests/api/v0/callback.test.ts
+++ b/tests/api/v0/callback.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockCallback = vi.fn()
+
+vi.mock('~/lib/prisma', () => ({
+  default: {
+    providers: {
+      findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    userIdentity: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    user: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('openid-client', () => ({
+  Issuer: { discover: vi.fn() },
+  generators: {
+    codeVerifier: vi.fn(),
+    codeChallenge: vi.fn(),
+  },
+  BaseClient: vi.fn(),
+  discovery: vi.fn(),
+  randomPKCECodeVerifier: vi.fn(),
+  calculatePKCECodeChallenge: vi.fn(),
+  randomState: vi.fn(),
+  buildAuthorizationUrl: vi.fn(),
+  authorizationCodeGrant: vi.fn(),
+}))
+
+vi.mock('~/api/common/clients', () => ({
+  clients: {
+    google: {
+      callback: mockCallback,
+    },
+  },
+  misskeyClients: {},
+}))
+
+vi.mock('jwt-decode', () => ({
+  jwtDecode: vi.fn().mockReturnValue({
+    sub: 'user-sub-123',
+    email: 'test@example.com',
+    name: 'Test User',
+    nickname: 'testuser',
+    preferred_username: 'testuser',
+    picture: 'https://example.com/avatar.png',
+  }),
+}))
+
+describe('api/v0/callback - OIDCコールバックフロー', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('callbackモジュールがエクスポートされる', async () => {
+    const { callback } = await import('~/api/v0/callback')
+    expect(callback).toBeDefined()
+  })
+
+  it('無効なプロバイダーで400エラーが返る', async () => {
+    const { callback } = await import('~/api/v0/callback')
+    const res = await callback.request(
+      new Request('http://localhost/invalid?code=xxx'),
+      undefined,
+      {}
+    )
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toBe('Invalid provider')
+  })
+
+  it('新規ユーザーが正しく作成される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockCallback.mockResolvedValue({
+      access_token: 'mock-access-token',
+      id_token: 'mock-id-token',
+      refresh_token: 'mock-refresh-token',
+      expires_in: 3600,
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'provider-1',
+      name: 'Google',
+      url: 'https://accounts.google.com',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      scope: 'openid profile email',
+      isMisskey: false,
+    } as any)
+
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.user.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.user.create).mockResolvedValue({
+      id: 'new-user-id',
+      mail: 'test@example.com',
+      name: 'Test User',
+      displayName: 'testuser',
+      avatarUrl: 'https://example.com/avatar.png',
+      isAdmin: false,
+      passwordId: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as any)
+    vi.mocked(prisma.userIdentity.create).mockResolvedValue({
+      id: 'identity-1',
+      providerId: 'provider-1',
+      sub: 'user-sub-123',
+      userId: 'new-user-id',
+      accessToken: 'mock-access-token',
+      idToken: 'mock-id-token',
+      refreshToken: 'mock-refresh-token',
+      expiresAt: new Date(),
+      user: { id: 'new-user-id', name: 'Test User' },
+    } as any)
+
+    const { callback } = await import('~/api/v0/callback')
+    const req = new Request(
+      'http://localhost/google?code=auth-code-123',
+      {
+        headers: {
+          Cookie: 'code_verifier=test-verifier',
+        },
+      }
+    )
+    const res = await callback.request(req, undefined, {})
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Login successful')
+    expect(body.user).toBeDefined()
+
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        mail: 'test@example.com',
+        name: 'Test User',
+      }),
+    })
+
+    expect(prisma.userIdentity.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        providerId: 'provider-1',
+        sub: 'user-sub-123',
+        accessToken: 'mock-access-token',
+        idToken: 'mock-id-token',
+        refreshToken: 'mock-refresh-token',
+      }),
+    })
+  })
+
+  it('既存ユーザーのトークンが更新される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockCallback.mockResolvedValue({
+      access_token: 'new-access-token',
+      id_token: 'new-id-token',
+      refresh_token: 'new-refresh-token',
+      expires_in: 3600,
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'provider-1',
+      name: 'Google',
+      url: 'https://accounts.google.com',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      scope: 'openid profile email',
+      isMisskey: false,
+    } as any)
+
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue({
+      id: 'existing-identity',
+      providerId: 'provider-1',
+      sub: 'user-sub-123',
+      userId: 'existing-user-id',
+      accessToken: 'old-access-token',
+      idToken: 'old-id-token',
+      refreshToken: 'old-refresh-token',
+      expiresAt: new Date(),
+      user: { id: 'existing-user-id', name: 'Existing User' },
+    } as any)
+
+    vi.mocked(prisma.userIdentity.update).mockResolvedValue({} as any)
+
+    const { callback } = await import('~/api/v0/callback')
+    const req = new Request(
+      'http://localhost/google?code=auth-code-456',
+      {
+        headers: {
+          Cookie: 'code_verifier=test-verifier',
+        },
+      }
+    )
+    const res = await callback.request(req, undefined, {})
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Login successful')
+
+    expect(prisma.userIdentity.update).toHaveBeenCalledWith({
+      where: { id: 'existing-identity' },
+      data: expect.objectContaining({
+        accessToken: 'new-access-token',
+        idToken: 'new-id-token',
+        refreshToken: 'new-refresh-token',
+      }),
+    })
+
+    expect(prisma.user.create).not.toHaveBeenCalled()
+  })
+
+  it('既存メールユーザーに新しいIdentityが紐付けられる', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockCallback.mockResolvedValue({
+      access_token: 'mock-access-token',
+      id_token: 'mock-id-token',
+      refresh_token: 'mock-refresh-token',
+      expires_in: 3600,
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'provider-1',
+      name: 'Google',
+      url: 'https://accounts.google.com',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      scope: 'openid profile email',
+      isMisskey: false,
+    } as any)
+
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.user.findFirst).mockResolvedValue({
+      id: 'existing-user-id',
+      mail: 'test@example.com',
+      name: 'Existing User',
+    } as any)
+    vi.mocked(prisma.userIdentity.create).mockResolvedValue({
+      id: 'new-identity',
+      providerId: 'provider-1',
+      sub: 'user-sub-123',
+      userId: 'existing-user-id',
+      user: { id: 'existing-user-id', name: 'Existing User' },
+    } as any)
+
+    const { callback } = await import('~/api/v0/callback')
+    const req = new Request(
+      'http://localhost/google?code=auth-code',
+      {
+        headers: { Cookie: 'code_verifier=test-verifier' },
+      }
+    )
+    const res = await callback.request(req, undefined, {})
+
+    expect(res.status).toBe(200)
+    expect(prisma.user.create).not.toHaveBeenCalled()
+    expect(prisma.userIdentity.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        userId: 'existing-user-id',
+      }),
+    })
+  })
+
+  it('auth_tokenがCookieに設定される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockCallback.mockResolvedValue({
+      access_token: 'mock-access-token',
+      id_token: 'mock-id-token-cookie-test',
+      refresh_token: 'mock-refresh-token',
+      expires_in: 3600,
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'provider-1', name: 'Google', url: 'https://accounts.google.com',
+      clientId: 'cid', clientSecret: 'cs', scope: 'openid', isMisskey: false,
+    } as any)
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue({
+      id: 'identity-1', user: { id: 'user-1' },
+    } as any)
+    vi.mocked(prisma.userIdentity.update).mockResolvedValue({} as any)
+
+    const { callback } = await import('~/api/v0/callback')
+    const req = new Request(
+      'http://localhost/google?code=code',
+      { headers: { Cookie: 'code_verifier=verifier' } }
+    )
+    const res = await callback.request(req, undefined, {})
+
+    const cookies = res.headers.get('set-cookie') || ''
+    expect(cookies).toContain('auth_token=')
+    expect(cookies).toContain('HttpOnly')
+  })
+
+  it('callback呼び出し時にcode_verifierが渡される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockCallback.mockResolvedValue({
+      access_token: 'at', id_token: 'it', refresh_token: 'rt', expires_in: 3600,
+    })
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'p1', name: 'Google', url: 'https://accounts.google.com',
+      clientId: 'cid', clientSecret: 'cs', scope: 'openid', isMisskey: false,
+    } as any)
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue({
+      id: 'i1', user: { id: 'u1' },
+    } as any)
+    vi.mocked(prisma.userIdentity.update).mockResolvedValue({} as any)
+
+    const { callback } = await import('~/api/v0/callback')
+    const req = new Request(
+      'http://localhost/google?code=the-auth-code',
+      { headers: { Cookie: 'code_verifier=my-verifier' } }
+    )
+    await callback.request(req, undefined, {})
+
+    expect(mockCallback).toHaveBeenCalledWith(
+      expect.any(String),
+      { code: 'the-auth-code' },
+      { code_verifier: 'my-verifier' }
+    )
+  })
+})

--- a/tests/api/v0/index.test.ts
+++ b/tests/api/v0/index.test.ts
@@ -86,15 +86,19 @@ describe('api/v0 - Honoルーター統合テスト', () => {
     expect(mod.default).toBeDefined()
   })
 
-  it('/api/v0/meが認証なしで401を返す契約を持つ', async () => {
-    // /me エンドポイントの仕様:
-    // - auth_token Cookieが無い場合 → 401
-    // - auth_token がある場合 → JWTデコード → ユーザー情報取得
-    // この契約はバージョン統一後も維持されるべき
-    const { jwtDecode } = await import('jwt-decode')
-    expect(jwtDecode).toBeDefined()
+  it('/api/v0/meが認証なしで401を返す', async () => {
+    const h3 = await import('h3')
+    vi.mocked(h3.toWebRequest).mockReturnValue(
+      new Request('http://localhost/api/v0/me') as any
+    )
 
-    const prisma = (await import('~/lib/prisma')).default
-    expect(prisma.user.findUnique).toBeDefined()
+    const mod = await import('~/api/v0/index')
+    const handler = mod.default as (event: any) => Promise<Response>
+
+    const fakeEvent = { node: { req: { originalUrl: '/api/v0/me' } } }
+    const res = await handler(fakeEvent)
+
+    expect(res.status).toBe(401)
+    expect(await res.text()).toBe('Unauthorized')
   })
 })

--- a/tests/api/v0/index.test.ts
+++ b/tests/api/v0/index.test.ts
@@ -69,15 +69,10 @@ describe('api/v0/index - Honoルーター', () => {
     vi.clearAllMocks()
   })
 
-  it('healthエンドポイントが正常応答を返す', async () => {
+  it('デフォルトエクスポートがdefineEventHandlerで生成されたハンドラーである', async () => {
     const mod = await import('~/api/v0/index')
-    const app = (mod as any).default
-
-    // Hono appは直接テストできないのでfetchを使う
-    // ただし defineEventHandler でラップされている
-    // index.ts のHonoアプリを直接テストするために、内部のappにアクセスする必要がある
-    // Hono appの .request() を使ってテスト
-    expect(mod).toBeDefined()
+    expect(mod.default).toBeDefined()
+    expect(typeof mod.default).toBe('function')
   })
 })
 

--- a/tests/api/v0/index.test.ts
+++ b/tests/api/v0/index.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('~/lib/prisma', () => ({
+  default: {
+    providers: {
+      findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    userIdentity: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    user: {
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      count: vi.fn().mockResolvedValue(42),
+    },
+  },
+}))
+
+vi.mock('openid-client', () => ({
+  Issuer: { discover: vi.fn() },
+  generators: { codeVerifier: vi.fn(), codeChallenge: vi.fn() },
+  BaseClient: vi.fn(),
+  discovery: vi.fn(),
+  randomPKCECodeVerifier: vi.fn(),
+  calculatePKCECodeChallenge: vi.fn(),
+  randomState: vi.fn(),
+  buildAuthorizationUrl: vi.fn(),
+  authorizationCodeGrant: vi.fn(),
+}))
+
+vi.mock('~/api/common/clients', () => ({
+  clients: {},
+  misskeyClients: {},
+}))
+
+vi.mock('~/api/common/helper/misskeyAuthStorage', () => ({
+  misskeyAuthStorage: {
+    setItem: vi.fn(),
+    getItem: vi.fn(),
+  },
+}))
+
+vi.mock('misskey-js', () => ({
+  api: {
+    APIClient: vi.fn().mockImplementation(() => ({
+      request: vi.fn(),
+    })),
+  },
+}))
+
+vi.mock('jwt-decode', () => ({
+  jwtDecode: vi.fn().mockReturnValue({
+    email: 'me@example.com',
+    sub: 'user-sub',
+  }),
+}))
+
+vi.mock('h3', () => ({
+  defineEventHandler: vi.fn((handler) => handler),
+  toWebRequest: vi.fn(),
+}))
+
+describe('api/v0/index - Honoルーター', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('healthエンドポイントが正常応答を返す', async () => {
+    const mod = await import('~/api/v0/index')
+    const app = (mod as any).default
+
+    // Hono appは直接テストできないのでfetchを使う
+    // ただし defineEventHandler でラップされている
+    // index.ts のHonoアプリを直接テストするために、内部のappにアクセスする必要がある
+    // Hono appの .request() を使ってテスト
+    expect(mod).toBeDefined()
+  })
+})
+
+describe('api/v0 - Honoルーター統合テスト', () => {
+  it('/api/v0/healthが{ ok: true }を返す', async () => {
+    // index.ts はdefineEventHandlerでラップされているため、
+    // Honoのappを直接exportしていない。
+    // ただしauth, callbackなどは個別にexportされているのでそちらで十分テスト済み。
+    // ここではモジュールが正常にimportできることを確認
+    const mod = await import('~/api/v0/index')
+    expect(mod.default).toBeDefined()
+  })
+
+  it('/api/v0/meが認証なしで401を返す契約を持つ', async () => {
+    // /me エンドポイントの仕様:
+    // - auth_token Cookieが無い場合 → 401
+    // - auth_token がある場合 → JWTデコード → ユーザー情報取得
+    // この契約はバージョン統一後も維持されるべき
+    const { jwtDecode } = await import('jwt-decode')
+    expect(jwtDecode).toBeDefined()
+
+    const prisma = (await import('~/lib/prisma')).default
+    expect(prisma.user.findUnique).toBeDefined()
+  })
+})

--- a/tests/api/v0/misskey.auth.test.ts
+++ b/tests/api/v0/misskey.auth.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockBuildAuthorizationUrl = vi.fn().mockReturnValue(new URL('https://misskey.io/auth'))
+const mockRandomPKCECodeVerifier = vi.fn().mockReturnValue('misskey-code-verifier')
+const mockCalculatePKCECodeChallenge = vi.fn().mockResolvedValue('misskey-code-challenge')
+const mockRandomState = vi.fn().mockReturnValue('misskey-random-state')
+
+vi.mock('~/lib/prisma', () => ({
+  default: {
+    providers: {
+      findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+  },
+}))
+
+vi.mock('openid-client', () => ({
+  Issuer: { discover: vi.fn() },
+  generators: { codeVerifier: vi.fn(), codeChallenge: vi.fn() },
+  BaseClient: vi.fn(),
+  discovery: vi.fn(),
+  randomPKCECodeVerifier: mockRandomPKCECodeVerifier,
+  calculatePKCECodeChallenge: mockCalculatePKCECodeChallenge,
+  randomState: mockRandomState,
+  buildAuthorizationUrl: mockBuildAuthorizationUrl,
+  authorizationCodeGrant: vi.fn(),
+}))
+
+const mockMisskeyConfig = { serverMetadata: () => ({ issuer: 'https://misskey.io' }) }
+
+vi.mock('~/api/common/clients', () => ({
+  clients: {},
+  misskeyClients: {
+    misskey: mockMisskeyConfig,
+  },
+}))
+
+vi.mock('~/api/common/helper/misskeyAuthStorage', () => ({
+  misskeyAuthStorage: {
+    setItem: vi.fn(),
+    getItem: vi.fn(),
+  },
+}))
+
+describe('api/v0/misskey.auth - Misskey認証フロー', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('misskeyAuthモジュールがエクスポートされる', async () => {
+    const { misskeyAuth } = await import('~/api/v0/misskey.auth')
+    expect(misskeyAuth).toBeDefined()
+  })
+
+  it('有効なMisskeyプロバイダーでリダイレクトされる', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1',
+      name: 'Misskey',
+      url: 'https://misskey.io',
+      clientId: 'misskey-client-id',
+      clientSecret: null,
+      scope: 'read:account',
+      isMisskey: true,
+    } as any)
+
+    const { misskeyAuth } = await import('~/api/v0/misskey.auth')
+    const res = await misskeyAuth.request(
+      new Request('http://localhost/misskey'),
+      undefined,
+      {}
+    )
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('https://misskey.io/auth')
+  })
+
+  it('無効なプロバイダーで400エラーが返る', async () => {
+    const { misskeyAuth } = await import('~/api/v0/misskey.auth')
+    const res = await misskeyAuth.request(
+      new Request('http://localhost/nonexistent'),
+      undefined,
+      {}
+    )
+
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toBe('Invalid provider')
+  })
+
+  it('PKCEパラメータが正しく生成される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+
+    const { misskeyAuth } = await import('~/api/v0/misskey.auth')
+    await misskeyAuth.request(
+      new Request('http://localhost/misskey'),
+      undefined,
+      {}
+    )
+
+    expect(mockRandomPKCECodeVerifier).toHaveBeenCalledOnce()
+    expect(mockCalculatePKCECodeChallenge).toHaveBeenCalledWith('misskey-code-verifier')
+    expect(mockRandomState).toHaveBeenCalledOnce()
+  })
+
+  it('buildAuthorizationUrlに正しいパラメータが渡される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+
+    const { misskeyAuth } = await import('~/api/v0/misskey.auth')
+    await misskeyAuth.request(
+      new Request('http://localhost/misskey'),
+      undefined,
+      {}
+    )
+
+    expect(mockBuildAuthorizationUrl).toHaveBeenCalledWith(
+      mockMisskeyConfig,
+      expect.objectContaining({
+        redirect_uri: expect.stringContaining('/api/v0/misskey/callback/misskey'),
+        scope: 'read:account',
+        code_challenge: 'misskey-code-challenge',
+        code_challenge_method: 'S256',
+        state: 'misskey-random-state',
+      })
+    )
+  })
+
+  it('code_verifierがCookieに設定される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+
+    const { misskeyAuth } = await import('~/api/v0/misskey.auth')
+    const res = await misskeyAuth.request(
+      new Request('http://localhost/misskey'),
+      undefined,
+      {}
+    )
+
+    const cookies = res.headers.get('set-cookie') || ''
+    expect(cookies).toContain('code_verifier=misskey-code-verifier')
+    expect(cookies).toContain('HttpOnly')
+  })
+
+  it('stateがmisskeyAuthStorageに保存される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+
+    const { misskeyAuthStorage } = await import('~/api/common/helper/misskeyAuthStorage')
+
+    const { misskeyAuth } = await import('~/api/v0/misskey.auth')
+    await misskeyAuth.request(
+      new Request('http://localhost/misskey'),
+      undefined,
+      {}
+    )
+
+    expect(misskeyAuthStorage.setItem).toHaveBeenCalledWith(
+      'misskey-code-verifier',
+      'misskey-random-state'
+    )
+  })
+})

--- a/tests/api/v0/misskey.callback.test.ts
+++ b/tests/api/v0/misskey.callback.test.ts
@@ -1,0 +1,298 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mockAuthorizationCodeGrant = vi.fn()
+const mockMisskeyConfig = { serverMetadata: () => ({ issuer: 'https://misskey.io' }) }
+const mockMisskeyApiRequest = vi.fn()
+
+vi.mock('~/lib/prisma', () => ({
+  default: {
+    providers: {
+      findFirst: vi.fn(),
+      findMany: vi.fn().mockResolvedValue([]),
+    },
+    userIdentity: {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    user: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('openid-client', () => ({
+  Issuer: { discover: vi.fn() },
+  generators: { codeVerifier: vi.fn(), codeChallenge: vi.fn() },
+  BaseClient: vi.fn(),
+  discovery: vi.fn(),
+  randomPKCECodeVerifier: vi.fn(),
+  calculatePKCECodeChallenge: vi.fn(),
+  randomState: vi.fn(),
+  buildAuthorizationUrl: vi.fn(),
+  authorizationCodeGrant: mockAuthorizationCodeGrant,
+}))
+
+vi.mock('~/api/common/clients', () => ({
+  clients: {},
+  misskeyClients: {
+    misskey: mockMisskeyConfig,
+  },
+}))
+
+vi.mock('~/api/common/helper/misskeyAuthStorage', () => ({
+  misskeyAuthStorage: {
+    setItem: vi.fn(),
+    getItem: vi.fn().mockResolvedValue('stored-state'),
+  },
+}))
+
+const MockAPIClient = vi.fn()
+
+vi.mock('misskey-js', () => {
+  class APIClient {
+    constructor(...args: any[]) {
+      MockAPIClient(...args)
+      this.request = mockMisskeyApiRequest
+    }
+    request: typeof mockMisskeyApiRequest
+  }
+  return {
+    api: { APIClient },
+  }
+})
+
+describe('api/v0/misskey.callback - Misskeyコールバックフロー', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('misskeyCallbackモジュールがエクスポートされる', async () => {
+    const { misskeyCallback } = await import('~/api/v0/misskey.callback')
+    expect(misskeyCallback).toBeDefined()
+  })
+
+  it('無効なプロバイダーで400エラーが返る', async () => {
+    const { misskeyCallback } = await import('~/api/v0/misskey.callback')
+    const res = await misskeyCallback.request(
+      new Request('http://localhost/invalid?code=xxx'),
+      undefined,
+      {}
+    )
+    expect(res.status).toBe(400)
+    const body = await res.text()
+    expect(body).toBe('Invalid provider')
+  })
+
+  it('新規Misskeyユーザーが正しく作成される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockAuthorizationCodeGrant.mockResolvedValue({
+      access_token: 'misskey-access-token',
+    })
+
+    mockMisskeyApiRequest.mockResolvedValue({
+      id: 'misskey-user-id',
+      username: 'misskeyuser',
+      name: 'Misskey User',
+      email: 'misskey@example.com',
+      avatarUrl: 'https://misskey.io/avatar.png',
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1',
+      name: 'Misskey',
+      url: 'https://misskey.io',
+      clientId: 'cid',
+      clientSecret: null,
+      scope: 'read:account',
+      isMisskey: true,
+    } as any)
+
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue(null)
+    vi.mocked(prisma.user.findFirst).mockResolvedValue(null)
+    vi.mocked(prisma.user.create).mockResolvedValue({
+      id: 'new-user',
+      mail: 'misskey@example.com',
+      name: 'misskeyuser',
+      displayName: 'Misskey User',
+      avatarUrl: 'https://misskey.io/avatar.png',
+    } as any)
+    vi.mocked(prisma.userIdentity.create).mockResolvedValue({
+      id: 'new-identity',
+      providerId: 'mp1',
+      sub: 'misskey-user-id',
+      userId: 'new-user',
+      accessToken: 'misskey-access-token',
+      user: { id: 'new-user', name: 'misskeyuser' },
+    } as any)
+
+    const { misskeyCallback } = await import('~/api/v0/misskey.callback')
+    const req = new Request(
+      'http://localhost/misskey?code=misskey-code',
+      { headers: { Cookie: 'code_verifier=mk-verifier' } }
+    )
+    const res = await misskeyCallback.request(req, undefined, {})
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.message).toBe('Login successful')
+
+    expect(prisma.user.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        mail: 'misskey@example.com',
+        name: 'misskeyuser',
+        displayName: 'Misskey User',
+        avatarUrl: 'https://misskey.io/avatar.png',
+      }),
+    })
+
+    expect(prisma.userIdentity.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        providerId: 'mp1',
+        sub: 'misskey-user-id',
+        accessToken: 'misskey-access-token',
+      }),
+    })
+  })
+
+  it('既存Misskeyユーザーのトークンが更新される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockAuthorizationCodeGrant.mockResolvedValue({
+      access_token: 'new-misskey-at',
+    })
+
+    mockMisskeyApiRequest.mockResolvedValue({
+      id: 'misskey-user-id',
+      username: 'misskeyuser',
+      name: 'Misskey User',
+      email: 'misskey@example.com',
+      avatarUrl: 'https://misskey.io/avatar.png',
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue({
+      id: 'existing-id',
+      providerId: 'mp1',
+      sub: 'misskey-user-id',
+      userId: 'existing-user',
+      user: { id: 'existing-user', name: 'misskeyuser' },
+    } as any)
+    vi.mocked(prisma.userIdentity.update).mockResolvedValue({} as any)
+
+    const { misskeyCallback } = await import('~/api/v0/misskey.callback')
+    const req = new Request(
+      'http://localhost/misskey?code=code',
+      { headers: { Cookie: 'code_verifier=mk-verifier' } }
+    )
+    const res = await misskeyCallback.request(req, undefined, {})
+
+    expect(res.status).toBe(200)
+
+    expect(prisma.userIdentity.update).toHaveBeenCalledWith({
+      where: { id: 'existing-id' },
+      data: { accessToken: 'new-misskey-at' },
+    })
+    expect(prisma.user.create).not.toHaveBeenCalled()
+  })
+
+  it('authorizationCodeGrantにPKCEとstateが渡される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockAuthorizationCodeGrant.mockResolvedValue({ access_token: 'at' })
+    mockMisskeyApiRequest.mockResolvedValue({
+      id: 'uid', username: 'user', name: 'User', email: 'u@e.com', avatarUrl: null,
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue({
+      id: 'i1', user: { id: 'u1' },
+    } as any)
+    vi.mocked(prisma.userIdentity.update).mockResolvedValue({} as any)
+
+    const { misskeyCallback } = await import('~/api/v0/misskey.callback')
+    const req = new Request(
+      'http://localhost/misskey?code=the-code',
+      { headers: { Cookie: 'code_verifier=stored-verifier' } }
+    )
+    await misskeyCallback.request(req, undefined, {})
+
+    expect(mockAuthorizationCodeGrant).toHaveBeenCalledWith(
+      mockMisskeyConfig,
+      expect.any(URL),
+      expect.objectContaining({
+        pkceCodeVerifier: 'stored-verifier',
+        expectedState: 'stored-state',
+      })
+    )
+  })
+
+  it('Misskey APIクライアントが正しいoriginとcredentialで作成される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockAuthorizationCodeGrant.mockResolvedValue({ access_token: 'mk-at-123' })
+    mockMisskeyApiRequest.mockResolvedValue({
+      id: 'uid', username: 'u', name: 'N', email: 'e@e.com', avatarUrl: null,
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io/.well-known/openid-configuration',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue({
+      id: 'i1', user: { id: 'u1' },
+    } as any)
+    vi.mocked(prisma.userIdentity.update).mockResolvedValue({} as any)
+
+    const { misskeyCallback } = await import('~/api/v0/misskey.callback')
+    const req = new Request(
+      'http://localhost/misskey?code=c',
+      { headers: { Cookie: 'code_verifier=v' } }
+    )
+    await misskeyCallback.request(req, undefined, {})
+
+    expect(MockAPIClient).toHaveBeenCalledWith({
+      origin: 'https://misskey.io',
+      credential: 'mk-at-123',
+    })
+    expect(mockMisskeyApiRequest).toHaveBeenCalledWith('i', {})
+  })
+
+  it('auth_tokenがCookieに設定される', async () => {
+    const prisma = (await import('~/lib/prisma')).default
+
+    mockAuthorizationCodeGrant.mockResolvedValue({ access_token: 'mk-cookie-token' })
+    mockMisskeyApiRequest.mockResolvedValue({
+      id: 'uid', username: 'u', name: 'N', email: 'e@e.com', avatarUrl: null,
+    })
+
+    vi.mocked(prisma.providers.findFirst).mockResolvedValue({
+      id: 'mp1', name: 'Misskey', url: 'https://misskey.io',
+      clientId: 'cid', clientSecret: null, scope: 'read:account', isMisskey: true,
+    } as any)
+    vi.mocked(prisma.userIdentity.findUnique).mockResolvedValue({
+      id: 'i1', user: { id: 'u1' },
+    } as any)
+    vi.mocked(prisma.userIdentity.update).mockResolvedValue({} as any)
+
+    const { misskeyCallback } = await import('~/api/v0/misskey.callback')
+    const req = new Request(
+      'http://localhost/misskey?code=c',
+      { headers: { Cookie: 'code_verifier=v' } }
+    )
+    const res = await misskeyCallback.request(req, undefined, {})
+
+    const cookies = res.headers.get('set-cookie') || ''
+    expect(cookies).toContain('auth_token=mk-cookie-token')
+    expect(cookies).toContain('HttpOnly')
+  })
+})

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "paths": {
+      "~/*": ["./*"],
+      "openid-client@6": ["./node_modules/openid-client"]
+    }
+  },
+  "include": ["tests/**/*.ts", "api/**/*.ts", "lib/**/*.ts"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '~': resolve(__dirname),
+      'openid-client@6': 'openid-client',
+    },
+  },
+  esbuild: {
+    tsconfigRaw: '{}',
+  },
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['api/**/*.ts'],
+    },
+  },
+})


### PR DESCRIPTION
Add comprehensive unit tests for authentication flows to ensure safety during `openid-client` version unification.

The current codebase uses both `openid-client` v5 and v6. These tests cover both API versions, allowing for safe refactoring and unification of the `openid-client` dependency without breaking existing authentication logic.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-7251ae72-727b-42cd-9b5d-917af0fd450d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7251ae72-727b-42cd-9b5d-917af0fd450d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions and tooling/config changes; production auth logic is not modified.
> 
> **Overview**
> Adds a Vitest-based test suite to lock down the current authentication behavior ahead of `openid-client` v5/v6 unification.
> 
> Introduces unit tests covering OIDC `auth` redirect/PKCE cookie behavior and `callback` user/identity create-or-update logic, plus parallel Misskey auth/callback tests exercising v6 APIs (`discovery`, `buildAuthorizationUrl`, `authorizationCodeGrant`) and `misskeyAuthStorage` state handling. Also wires up `vitest` scripts/config (`vitest.config.ts`, `tsconfig.test.json`) and adds coverage support via `@vitest/coverage-v8` (lockfile updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cfab09f72b59dc2abeebf3770e71e5e22a0d707. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * API認証フロー（OIDC/Misskey含む）、エンドポイント挙動、各種ユニット/統合シナリオを網羅する包括的なテストスイートを追加しました。

* **Chores**
  * テスト実行スクリプトを追加（実行・ウォッチ・カバレッジ）。
  * テスト環境設定を追加／整備（Vitest構成、テスト用TypeScript設定、カバレッジ収集）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->